### PR TITLE
refactor: move socket identity resolution to middleware

### DIFF
--- a/frontend/src/context/socketContext.tsx
+++ b/frontend/src/context/socketContext.tsx
@@ -17,7 +17,7 @@ const SocketContext = createContext<SocketContextType>({
   socket: null,
   connected: false,
   userReady: false,
-  setUserReady: () => {},
+  setUserReady: () => { },
 });
 
 // Custom hook to access the socket from context
@@ -45,7 +45,12 @@ const SocketProvider = ({ children }: { children: ReactNode }) => {
     socket.on("connect", onConnect);
     socket.on("disconnect", onDisconnect);
 
-    registerCoreSocketEvents(socket);
+    registerCoreSocketEvents(socket, {
+      onSessionInit: (session) => {
+        console.log("Session ready in provider:", session);
+        setUserReady(true);
+      },
+    });
 
     return () => {
       // IMPORTANT:

--- a/frontend/src/pages/dashboard.tsx
+++ b/frontend/src/pages/dashboard.tsx
@@ -9,52 +9,32 @@ import { useLocation } from "../hooks/useLocation";
 import { useCryptoTickerSubscription } from "../hooks/useCryptoTickerSubscription";
 import { useCryptoTopCoinsSubscription } from "../hooks/useCryptoTopCoinsSubscription";
 import { useCryptoMoversSubscription } from "../hooks/useCryptoMoversSubscription";
-import { LocalStorage } from "../utils";
 import debounce from 'lodash.debounce';
 
 
 const DashboardPage = () => {
 
     const location = useLocation();
-    const { socket, connected, setUserReady, userReady } = useSocket();
+    const { socket, connected, userReady } = useSocket();
     useCryptoTickerSubscription();
     useCryptoTopCoinsSubscription();
     useCryptoMoversSubscription();
     const sendRef = useRef(
-        debounce((socket: any, location: any, id: string) => {
-            socket.emit('userLocationUpdate', location, id);
+        debounce((socket: any, location: any) => {
+            socket.emit('userLocationUpdate', location);
         }, 1000) // debounce location updates before emitting
     );
 
     useEffect(() => {
         // Check if socket is available
-        if (!socket || !connected || !location) return;
+        if (!socket || !connected || !location || !userReady) return;
 
-        const storedId = LocalStorage.get('userid');
-
-        if (storedId) {
-            sendRef.current(socket, location, storedId);
-            setUserReady(true);
-        } else {
-            socket.emit('getUserId');
-        }
-
-        const handler = (id: string) => {
-            const currentId = LocalStorage.get('userid');
-            if (!currentId) {
-                LocalStorage.set('userid', id);
-                sendRef.current(socket, location, id);
-                setUserReady(true);
-            }
-        }
-
-        socket.on('userUniqueId', handler);
+        sendRef.current(socket, location);
 
         return () => {
-            socket.off('userUniqueId', handler);
             sendRef.current.cancel(); // prevent debounced emits after unmount
         };
-    }, [socket, connected, location]);
+    }, [socket, connected, location, userReady]);
 
     if (!userReady) {
         return (

--- a/frontend/src/socket/socketEvents.ts
+++ b/frontend/src/socket/socketEvents.ts
@@ -1,6 +1,15 @@
 import { Socket } from "socket.io-client";
 
-export const registerCoreSocketEvents = (socket: Socket) => {
+type SessionInitPayload = {
+  userId: string;
+  userType: "guest" | "authenticated";
+};
+
+type CoreSocketEventHandlers = {
+  onSessionInit?: (session: SessionInitPayload) => void;
+};
+
+export const registerCoreSocketEvents = (socket: Socket, handlers?: CoreSocketEventHandlers) => {
   socket.on("connect", () => {
     console.log("Connected:", socket.id);
   });
@@ -11,6 +20,11 @@ export const registerCoreSocketEvents = (socket: Socket) => {
 
   socket.on("connect_error", (error) => {
     console.error("Connection error:", error.message);
+  });
+
+  socket.on("session:init", (session: SessionInitPayload) => {
+    console.log("Resolved session:", session);
+    handlers?.onSessionInit?.(session);
   });
 
   socket.io.on("reconnect_attempt", (attempt) => {
@@ -30,6 +44,7 @@ export const unregisterCoreSocketEvents = (socket: Socket) => {
   socket.off("connect");
   socket.off("disconnect");
   socket.off("connect_error");
+  socket.off("session:init");
 
   socket.io.off("reconnect_attempt");
   socket.io.off("reconnect");

--- a/frontend/src/socket/socketSingleton.ts
+++ b/frontend/src/socket/socketSingleton.ts
@@ -2,6 +2,17 @@ import { io, Socket } from "socket.io-client";
 
 let socket: Socket | null = null;
 
+const GUEST_ID_KEY = "flux_guest_id";
+
+function getOrCreateGuestId(): string {
+    const existing = localStorage.getItem(GUEST_ID_KEY);
+    if (existing) return existing;
+
+    const newId = crypto.randomUUID();
+    localStorage.setItem(GUEST_ID_KEY, newId);
+    return newId;
+}
+
 export const getSocket = (): Socket => {
     if (!socket) {
         const serverUrl = window.location.hostname.includes('.dev')
@@ -19,6 +30,10 @@ export const getSocket = (): Socket => {
             reconnectionDelay: 1000,        // start at 1s
             reconnectionDelayMax: 5000,     // cap at 5s
             timeout: 20000,                 // connection timeout
+
+            auth: {
+                guestId: getOrCreateGuestId(),
+            },
         });
     }
     return socket;

--- a/frontend/tests/unit/socketContext.test.tsx
+++ b/frontend/tests/unit/socketContext.test.tsx
@@ -68,7 +68,12 @@ describe('SocketProvider (unit)', () => {
     );
 
     expect(getSocket).toHaveBeenCalled();
-    expect(registerCoreSocketEvents).toHaveBeenCalledWith(socket);
+    expect(registerCoreSocketEvents).toHaveBeenCalledWith(
+      socket,
+      expect.objectContaining({
+        onSessionInit: expect.any(Function),
+      })
+    );
   });
 
   it('sets connected=true on socket connect', () => {

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -56,6 +56,43 @@ const logger = pino({
 });
 logger.info(env.NODE_ENV, logger.level);
 
+// -------------------------------------------------
+// Socket identity typing
+// -------------------------------------------------
+type SocketUserType = 'guest';
+
+interface SocketUser {
+    id: string;
+    type: SocketUserType;
+    ip: string;
+}
+
+declare module 'socket.io' {
+    interface SocketData {
+        user: SocketUser;
+    }
+}
+
+// -------------------------------------------------
+// Helpers
+// -------------------------------------------------
+function resolveClientIp(socket: Socket): string {
+    const forwarded = socket.handshake.headers['x-forwarded-for'];
+    return forwarded?.toString().split(',')[0].trim() || socket.handshake.address;
+}
+
+function resolveGuestId(socket: Socket): string {
+    const rawGuestId = socket.handshake.auth?.guestId;
+
+    if (typeof rawGuestId === 'string' &&
+        rawGuestId.trim().length > 0 &&
+        rawGuestId.trim().length <= 128
+    ) {
+        return rawGuestId.trim();
+    }
+
+    return uuidv4();
+}
 
 // -------------------------------------------------
 // Kafka connection
@@ -149,6 +186,9 @@ async function initProducer() {
     }
 }
 
+// -------------------------------------------------
+// Kafka command helpers
+// -------------------------------------------------
 async function sendCryptoMoversRefresh(producer: Producer, logger: pino.Logger) {
     const payload = {
         requestedBy: 'bff',
@@ -253,25 +293,63 @@ const io = new Server(server, {
     }
 });
 
+// -------------------------------------------------
+// Identity middleware
+// -------------------------------------------------
+io.use((socket, next) => {
+    try {
+        const ip = resolveClientIp(socket);
+        const guestId = resolveGuestId(socket);
+
+        socket.data.user = {
+            id: guestId,
+            type: 'guest',
+            ip,
+        };
+
+        logger.debug(
+            {
+                socketId: socket.id,
+                userId: socket.data.user.id,
+                userType: socket.data.user.type,
+                ip,
+            },
+            'Socket identity resolved during connection'
+        );
+
+        next();
+    } catch (err) {
+        logger.error({ err, socketId: socket.id }, 'Failed to resolve socket identity');
+        next(new Error('Unable to initialize socket session'));
+    }
+});
+
 
 // -------------------------------------------------
 // Socket event handlers
 // -------------------------------------------------
 io.on('connection', (socket: Socket) => {
-    logger.info({ socketId: socket.id }, 'Client connected');
+    logger.info(
+        {
+            socketId: socket.id,
+            userId: socket.data.user.id,
+            userType: socket.data.user.type,
+            ip: socket.data.user.ip,
+        },
+        'Client connected'
+    );
 
-    socket.on('getUserId', () => {
-        const forwarded = socket.handshake.headers["x-forwarded-for"];
-        const ip = forwarded?.toString().split(",")[0].trim() || socket.handshake.address;
-
-        logger.debug({ socketId: socket.id, ip }, 'Client IP resolved');
-
-        const uniqueId = uuidv4();
-        socket.emit('userUniqueId', uniqueId);
+    // Bootstrap event so frontend can read the resolved identity
+    // without calling getUserId.
+    socket.emit('session:init', {
+        userId: socket.data.user.id,
+        userType: socket.data.user.type,
     });
 
     // User joining event
-    socket.on('userLocationUpdate', async (locationData: Location, userId: string) => {
+    socket.on('userLocationUpdate', async (locationData: Location) => {
+        const userId = socket.data.user.id;
+
         logger.debug({ socketId: socket.id, locationData, userId }, 'Location received');
 
         const cityName = locationData.city || 'Delhi';
@@ -332,7 +410,7 @@ io.on('connection', (socket: Socket) => {
 
         const payload = {
             event: 'locationUpdate',
-            userId,
+            userId: userId,
             data: locationData,
             timestamp: new Date().toISOString()
         };
@@ -402,7 +480,7 @@ io.on('connection', (socket: Socket) => {
     });
 
     // Stock events
-    socket.on('stockTopPerformersRequest', async (userId: string) => {
+    socket.on('stockTopPerformersRequest', async () => {
         try {
             const cached = await cacheGet<any>(STOCK_TOP_PERFORMERS_CACHE_KEY);
             logger.debug('stockTopPerformersRequest::cached:::: ', cached, new Date().toLocaleString())
@@ -458,7 +536,15 @@ io.on('connection', (socket: Socket) => {
     });
 
     socket.on('disconnect', (reason) => {
-        logger.info({ socketId: socket.id, reason }, 'Client disconnected');
+        logger.info(
+            {
+                socketId: socket.id,
+                userId: socket.data.user.id,
+                userType: socket.data.user.type,
+                reason,
+            },
+            'Client disconnected'
+        );
     });
 });
 


### PR DESCRIPTION
Closes #1

## Summary
Move identity resolution into the Socket.IO connection lifecycle and remove the `getUserId` flow.

## Changes
- resolve guest identity during socket handshake
- attach identity to `socket.data.user`
- add `session:init` event
- update frontend socket init to send `guestId`
- remove post-connect identity negotiation from the dashboard

## Result
- guest access still works
- existing realtime flows remain unchanged
- identity is now available at connection time